### PR TITLE
23 - Add export at end of file rule with autofix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .history/
 node_modules/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ class Foo { bar = () => {} }
 ## Preset Configurations
 
 - `**recommended**` - Enables `type-ordering` as error and `no-loops` as warning
-- `**all**` - Enables all rules (`type-ordering`, `no-loops`, `no-named-arrow-functions`, `export-at-end-of-file`) as errors
+- `**all**` - Enables `type-ordering`, `no-loops`, and `no-named-arrow-functions` as errors
 
 # Release Procedure
 
@@ -134,14 +134,17 @@ class Foo { bar = () => {} }
 4. Add code samples in `test/` that intentionally fail your new or updated rules to confirm they are caught.
 5. Commit and push your changes, then open a PR.
 6. **Bump to a pre-release version and publish a beta:**
+
   ```bash
    yarn version --pre[major|minor|patch] --preid beta
    npm publish --tag beta                # or alpha, rc
   ```
+
    Users can test it with:
 7. After review, **merge your branch into `main`**.
 8. Open a version bump PR against `main` and merge it in.
 9. **Publish the stable release** from `main`:
+
   ```bash
    yarn version --[major|minor|patch]
    npm publish

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ class Foo { bar = () => {} }
 ## Preset Configurations
 
 - `**recommended**` - Enables `type-ordering` as error and `no-loops` as warning
-- `**all**` - Enables all rules (`type-ordering`, `no-loops`, `no-named-arrow-functions`) as errors
+- `**all**` - Enables all rules (`type-ordering`, `no-loops`, `no-named-arrow-functions`, `export-at-end-of-file`) as errors
 
 # Release Procedure
 

--- a/README.md
+++ b/README.md
@@ -152,3 +152,46 @@ class Foo { bar = () => {} }
 # Development
 - Use https://astexplorer.net/ to easily get the AST types for your changes
 
+## Adding tests
+
+Tests are fixture-based. All test cases live in a single file, `test/fixtures.ts`, and the runner (`test/run.js`) lints that file with ESLint, parses the JSON output, and compares it against inline annotations.
+
+### Annotations
+
+Each line in `test/fixtures.ts` may carry one or both of the following trailing comments:
+
+- `// expect-error <ruleId>` — the line must produce a violation reported by `<ruleId>` (e.g. `yenz/no-loops`).
+- `// fix: <expected-code>` — after running ESLint with `--fix-dry-run`, the line (with the `// expect-error ...` annotation stripped) must equal `<expected-code>`.
+
+Lines without `// expect-error` must produce **no** violations. Unexpected violations fail the test, just like missing ones.
+
+### Adding a positive case (rule should fire)
+
+Add a line that violates the rule and annotate it:
+
+```typescript
+const foo = () => {} // expect-error yenz/no-named-arrow-functions
+```
+
+If the rule is auto-fixable, also include the expected fixed output:
+
+```typescript
+const foo = () => {} // expect-error yenz/no-named-arrow-functions // fix: function foo() {}
+```
+
+### Adding a negative case (rule should not fire)
+
+Add the code with no annotation. A short `// Should pass:` comment above the block keeps the file readable:
+
+```typescript
+// Should pass:
+const arr = [1, 2, 3].map(x => x)
+```
+
+### Running tests
+
+```bash
+yarn test
+```
+
+The runner reports `Violations: X/Y passed` and `Fixes: X/Y passed`, and exits non-zero on any missing violation, unexpected violation, or fix mismatch.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ type C = string | number | null | undefined
 
 Disallows `for`, `while`, and `do...while` loops. `for...of` and `for...in` are allowed.
 
-> **Note:** This rule is _not_ enabled in the `recommended` preset. Enable it explicitly or use the `all` preset.
+> **Note:** This rule is *not* enabled in the `recommended` preset. Enable it explicitly or use the `all` preset.
 
 **Bad:**
 
@@ -96,7 +96,7 @@ items.map(item => transform(item))
 
 Disallows arrow functions assigned to named variables. Prefer function declarations instead. Auto-fixable.
 
-> **Note:** This rule is _not_ enabled in the `recommended` preset. Enable it explicitly or use the `all` preset.
+> **Note:** This rule is *not* enabled in the `recommended` preset. Enable it explicitly or use the `all` preset.
 
 **Bad:**
 
@@ -123,8 +123,8 @@ class Foo { bar = () => {} }
 
 ## Preset Configurations
 
-- **`recommended`** - Enables `type-ordering` as error and `no-loops` as warning
-- **`all`** - Enables all rules (`type-ordering`, `no-loops`, `no-named-arrow-functions`) as errors
+- `**recommended**` - Enables `type-ordering` as error and `no-loops` as warning
+- `**all**` - Enables all rules (`type-ordering`, `no-loops`, `no-named-arrow-functions`) as errors
 
 # Release Procedure
 
@@ -134,20 +134,21 @@ class Foo { bar = () => {} }
 4. Add code samples in `test/` that intentionally fail your new or updated rules to confirm they are caught.
 5. Commit and push your changes, then open a PR.
 6. **Bump to a pre-release version and publish a beta:**
-   ```bash
+  ```bash
    yarn version --pre[major|minor|patch] --preid beta
    npm publish --tag beta                # or alpha, rc
-   ```
+  ```
    Users can test it with:
-   ```bash
-   yarn add eslint-plugin-yenz@beta   # or @alpha, @rc
-   ```
 7. After review, **merge your branch into `main`**.
 8. Open a version bump PR against `main` and merge it in.
-8. **Publish the stable release** from `main`:
-   ```bash
+9. **Publish the stable release** from `main`:
+  ```bash
    yarn version --[major|minor|patch]
    npm publish
-   ```
+  ```
 
 > **Why `yarn version` + `npm publish`?** `yarn version` handles the version bump, git tag, and commit. We use `npm publish` for the actual publish because `yarn publish` redundantly prompts for a new version even when one was already set.
+
+# Development
+- Use https://astexplorer.net/ to easily get the AST types for your changes
+

--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
 import typeOrdering from './lib/rules/type-ordering.js';
 import noLoops from './lib/rules/no-loops.js';
 import noNamedArrowFunctions from './lib/rules/no-named-arrow-functions.js';
+import exportAtEndOfFile from './lib/rules/export-at-end-of-file.js';
 
 const plugin = {
   rules: {
     'type-ordering': typeOrdering,
     'no-loops': noLoops,
     'no-named-arrow-functions': noNamedArrowFunctions,
+    'export-at-end-of-file': exportAtEndOfFile,
   },
 };
 

--- a/lib/rules/export-at-end-of-file.js
+++ b/lib/rules/export-at-end-of-file.js
@@ -149,6 +149,49 @@ function formatMergedSpecifierExport(items) {
     .join(', ')} }`;
 }
 
+/**
+ * Returns a location that covers only the exported header (for example
+ * `export function foo()` through the closing `)`), not the whole declaration
+ * body, so editors underline the signature instead of the entire block.
+ *
+ * @param {object} exportNamedNode - Inline `ExportNamedDeclaration`.
+ * @param {import('eslint').SourceCode} sourceCode
+ * @returns {object} ESLint `SourceLocation` (`start` / `end` in line/column).
+ */
+function getInlineExportReportLoc(exportNamedNode, sourceCode) {
+  const declaration = exportNamedNode.declaration;
+  const { start } = exportNamedNode.loc;
+
+  const endsBeforeBraceBody =
+    (declaration.type === 'FunctionDeclaration'
+      || declaration.type === 'ClassDeclaration'
+      || declaration.type === 'TSInterfaceDeclaration')
+    && declaration.body;
+
+  if (endsBeforeBraceBody) {
+    const bodyOpenIndex = declaration.body.range[0];
+    return {
+      start,
+      end: sourceCode.getLocFromIndex(bodyOpenIndex),
+    };
+  }
+
+  if (declaration.type === 'TSTypeAliasDeclaration') {
+    const anchor = declaration.typeParameters ?? declaration.id;
+    const equalsToken = sourceCode.getTokenAfter(anchor, {
+      filter: (token) => token.type === 'Punctuator' && token.value === '=',
+    });
+    if (equalsToken) {
+      return {
+        start,
+        end: sourceCode.getLocFromIndex(equalsToken.range[0]),
+      };
+    }
+  }
+
+  return exportNamedNode.loc;
+}
+
 const exportAtEndOfFileRule = {
   meta: {
     type: 'suggestion',
@@ -180,7 +223,7 @@ const exportAtEndOfFileRule = {
 
         violations.forEach((node) => {
           context.report({
-            node,
+            loc: getInlineExportReportLoc(node, sourceCode),
             message:
               'Declare this without inline export and list it in a single export statement at the end of the file.',
             ...(node === lastViolation

--- a/lib/rules/export-at-end-of-file.js
+++ b/lib/rules/export-at-end-of-file.js
@@ -1,0 +1,204 @@
+function getExportedNamesFromDeclaration(declaration) {
+  if (declaration.type === 'FunctionDeclaration') {
+    return declaration.id ? [declaration.id.name] : [];
+  }
+  if (declaration.type === 'ClassDeclaration') {
+    return declaration.id ? [declaration.id.name] : [];
+  }
+  if (declaration.type === 'TSTypeAliasDeclaration') {
+    return declaration.id ? [declaration.id.name] : [];
+  }
+  if (declaration.type === 'TSInterfaceDeclaration') {
+    return declaration.id ? [declaration.id.name] : [];
+  }
+  return [];
+}
+
+function isTypeOnlyDeclaration(declaration) {
+  return (
+    declaration.type === 'TSTypeAliasDeclaration' ||
+    declaration.type === 'TSInterfaceDeclaration'
+  );
+}
+
+function isSpecifierExportTypeOnly(specifier, parentExportNode) {
+  if (specifier.exportKind === 'type' || specifier.importKind === 'type') {
+    return true;
+  }
+  if (
+    parentExportNode.exportKind === 'type' &&
+    !parentExportNode.declaration
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function isInlineExportableDeclaration(node) {
+  if (node.type !== 'ExportNamedDeclaration') {
+    return false;
+  }
+  if (!node.declaration || node.source) {
+    return false;
+  }
+  const { declaration } = node;
+  if (declaration.type === 'FunctionDeclaration') {
+    return Boolean(declaration.id);
+  }
+  if (declaration.type === 'ClassDeclaration') {
+    return Boolean(declaration.id);
+  }
+  if (declaration.type === 'TSTypeAliasDeclaration') {
+    return Boolean(declaration.id);
+  }
+  if (declaration.type === 'TSInterfaceDeclaration') {
+    return Boolean(declaration.id);
+  }
+  return false;
+}
+
+function getViolationExportItems(exportNamedNode) {
+  const declaration = exportNamedNode.declaration;
+  const names = getExportedNamesFromDeclaration(declaration);
+  const isType = isTypeOnlyDeclaration(declaration);
+  return names.map((name) => ({ name, isType }));
+}
+
+function parseSpecifierOnlyExportItems(exportNode) {
+  if (exportNode.declaration || exportNode.source) {
+    return null;
+  }
+  if (exportNode.specifiers.length === 0) {
+    return null;
+  }
+  const items = [];
+  for (const specifier of exportNode.specifiers) {
+    if (specifier.type !== 'ExportSpecifier') {
+      continue;
+    }
+    if (specifier.exported.type !== 'Identifier') {
+      continue;
+    }
+    items.push({
+      name: specifier.exported.name,
+      isType: isSpecifierExportTypeOnly(specifier, exportNode),
+    });
+  }
+  return items.length > 0 ? items : null;
+}
+
+function findTrailingSpecifierOnlyExport(programNode) {
+  for (statement of programNode.body) {
+    if (statement.type !== 'ExportNamedDeclaration') {
+      continue;
+    }
+    if (statement.declaration || statement.source) {
+      continue;
+    }
+    if (statement.specifiers.length === 0) {
+      continue;
+    }
+    return statement;
+  }
+  return null;
+}
+
+function mergeExportItems(existingItems, addedItems) {
+  const seen = new Set();
+  const merged = [];
+  for (const item of [...existingItems, ...addedItems]) {
+    if (seen.has(item.name)) {
+      continue;
+    }
+    seen.add(item.name);
+    merged.push(item);
+  }
+  return merged;
+}
+
+function formatMergedSpecifierExport(items) {
+  if (items.length === 0) {
+    return 'export {}';
+  }
+  const allType = items.every((item) => item.isType);
+  if (allType) {
+    return `export type { ${items.map((item) => item.name).join(', ')} }`;
+  }
+  return `export { ${items
+    .map((item) => (item.isType ? `type ${item.name}` : item.name))
+    .join(', ')} }`;
+}
+
+const exportAtEndOfFileRule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow inline export on function, class, type, or interface declarations; use a single export list at the end of the file',
+      recommended: false,
+    },
+    fixable: 'code',
+    schema: [],
+  },
+  create(context) {
+    const sourceCode = context.sourceCode || context.getSourceCode();
+
+    return {
+      'Program:exit'(programNode) {
+        const violations = programNode.body.filter(isInlineExportableDeclaration);
+
+        if (violations.length === 0) {
+          return;
+        }
+
+        const addedExportItems = violations.flatMap(getViolationExportItems);
+
+        violations.forEach((node, index) => {
+          const isLast = index === violations.length - 1;
+
+          context.report({
+            node,
+            message:
+              'Declare this without inline export and list it in a single export statement at the end of the file.',
+            ...(isLast
+              ? {
+                  fix(fixer) {
+                    const edits = violations.map((exportNode) =>
+                      fixer.replaceText(
+                        exportNode,
+                        sourceCode.getText(exportNode.declaration)
+                      )
+                    );
+
+                    const trailingSpecifierExport = findTrailingSpecifierOnlyExport(programNode);
+                    const canMergeIntoTrailing = trailingSpecifierExport && !violations.includes(trailingSpecifierExport);
+                    if (canMergeIntoTrailing) {
+                      const existingItems = parseSpecifierOnlyExportItems(trailingSpecifierExport);
+                      const mergedItems = mergeExportItems(existingItems, addedExportItems);
+                      edits.push(
+                        fixer.replaceText(
+                          trailingSpecifierExport,
+                          formatMergedSpecifierExport(mergedItems)
+                        )
+                      );
+                    } else {
+                      const lastProgramToken =
+                        sourceCode.getLastToken(programNode);
+                      const exportLine = `\n\n${formatMergedSpecifierExport(addedExportItems)}`;
+                      edits.push(
+                        fixer.insertTextAfter(lastProgramToken, exportLine)
+                      );
+                    }
+
+                    return edits;
+                  },
+                }
+              : {}),
+          });
+        });
+      },
+    };
+  },
+};
+
+export default exportAtEndOfFileRule;

--- a/lib/rules/export-at-end-of-file.js
+++ b/lib/rules/export-at-end-of-file.js
@@ -1,115 +1,61 @@
-function getExportedNamesFromDeclaration(declaration) {
-  if (declaration.type === 'FunctionDeclaration') {
-    return declaration.id ? [declaration.id.name] : [];
-  }
-  if (declaration.type === 'ClassDeclaration') {
-    return declaration.id ? [declaration.id.name] : [];
-  }
-  if (declaration.type === 'TSTypeAliasDeclaration') {
-    return declaration.id ? [declaration.id.name] : [];
-  }
-  if (declaration.type === 'TSInterfaceDeclaration') {
-    return declaration.id ? [declaration.id.name] : [];
-  }
-  return [];
-}
+const EXPORTABLE_DECLARATION_TYPES = new Set([
+  'FunctionDeclaration',
+  'ClassDeclaration',
+  'TSTypeAliasDeclaration',
+  'TSInterfaceDeclaration',
+]);
 
-function isTypeOnlyDeclaration(declaration) {
-  return (
-    declaration.type === 'TSTypeAliasDeclaration' ||
-    declaration.type === 'TSInterfaceDeclaration'
-  );
-}
-
-function isSpecifierExportTypeOnly(specifier, parentExportNode) {
-  if (specifier.exportKind === 'type' || specifier.importKind === 'type') {
-    return true;
-  }
-  if (
-    parentExportNode.exportKind === 'type' &&
-    !parentExportNode.declaration
-  ) {
-    return true;
-  }
-  return false;
-}
+const TYPE_ONLY_DECLARATION_TYPES = new Set([
+  'TSTypeAliasDeclaration',
+  'TSInterfaceDeclaration',
+]);
 
 function isInlineExportableDeclaration(node) {
-  if (node.type !== 'ExportNamedDeclaration') {
-    return false;
-  }
-  if (!node.declaration || node.source) {
+  if (node.type !== 'ExportNamedDeclaration' || node.source || !node.declaration) {
     return false;
   }
   const { declaration } = node;
-  if (declaration.type === 'FunctionDeclaration') {
-    return Boolean(declaration.id);
-  }
-  if (declaration.type === 'ClassDeclaration') {
-    return Boolean(declaration.id);
-  }
-  if (declaration.type === 'TSTypeAliasDeclaration') {
-    return Boolean(declaration.id);
-  }
-  if (declaration.type === 'TSInterfaceDeclaration') {
-    return Boolean(declaration.id);
-  }
-  return false;
+  return EXPORTABLE_DECLARATION_TYPES.has(declaration.type) && Boolean(declaration.id);
 }
 
-function getViolationExportItems(exportNamedNode) {
-  const declaration = exportNamedNode.declaration;
-  const names = getExportedNamesFromDeclaration(declaration);
-  const isType = isTypeOnlyDeclaration(declaration);
-  return names.map((name) => ({ name, isType }));
+function getExportItem(exportNamedNode) {
+  const { declaration } = exportNamedNode;
+  return {
+    name: declaration.id.name,
+    isType: TYPE_ONLY_DECLARATION_TYPES.has(declaration.type),
+  };
 }
 
-function parseSpecifierOnlyExportItems(exportNode) {
-  if (exportNode.declaration || exportNode.source) {
-    return null;
-  }
-  if (exportNode.specifiers.length === 0) {
-    return null;
-  }
+function getSpecifierOnlyExportItems(exportNode) {
   const items = [];
   for (const specifier of exportNode.specifiers) {
-    if (specifier.type !== 'ExportSpecifier') {
+    if (specifier.type !== 'ExportSpecifier' || specifier.exported.type !== 'Identifier') {
       continue;
     }
-    if (specifier.exported.type !== 'Identifier') {
-      continue;
-    }
-    items.push({
-      name: specifier.exported.name,
-      isType: isSpecifierExportTypeOnly(specifier, exportNode),
-    });
+    const isType =
+      specifier.exportKind === 'type' ||
+      (exportNode.exportKind === 'type' && !exportNode.declaration);
+    items.push({ name: specifier.exported.name, isType });
   }
-  return items.length > 0 ? items : null;
+  return items;
 }
 
-function findTrailingSpecifierOnlyExport(programNode) {
-  for (statement of programNode.body) {
-    if (statement.type !== 'ExportNamedDeclaration') {
-      continue;
-    }
-    if (statement.declaration || statement.source) {
-      continue;
-    }
-    if (statement.specifiers.length === 0) {
-      continue;
-    }
-    return statement;
-  }
-  return null;
+function findSpecifierOnlyExport(programNode) {
+  const results = programNode.body.find(statement => statement.type === 'ExportNamedDeclaration'
+     && !statement.declaration && !statement.source && statement.specifiers.length > 0);
+  return results || null;
 }
 
 function mergeExportItems(existingItems, addedItems) {
   const seen = new Set();
   const merged = [];
-  for (const item of [...existingItems, ...addedItems]) {
-    if (seen.has(item.name)) {
-      continue;
-    }
+  for (const item of existingItems) {
+    if (seen.has(item.name)) continue;
+    seen.add(item.name);
+    merged.push(item);
+  }
+  for (const item of addedItems) {
+    if (seen.has(item.name)) continue;
     seen.add(item.name);
     merged.push(item);
   }
@@ -120,8 +66,7 @@ function formatMergedSpecifierExport(items) {
   if (items.length === 0) {
     return 'export {}';
   }
-  const allType = items.every((item) => item.isType);
-  if (allType) {
+  if (items.every((item) => item.isType)) {
     return `export type { ${items.map((item) => item.name).join(', ')} }`;
   }
   return `export { ${items
@@ -141,52 +86,46 @@ const exportAtEndOfFileRule = {
     schema: [],
   },
   create(context) {
-    const sourceCode = context.sourceCode || context.getSourceCode();
+    const { sourceCode } = context;
 
     return {
       'Program:exit'(programNode) {
         const violations = programNode.body.filter(isInlineExportableDeclaration);
-
         if (violations.length === 0) {
           return;
         }
 
-        const addedExportItems = violations.flatMap(getViolationExportItems);
+        const addedExportItems = violations.map(getExportItem);
+        const lastViolation = violations[violations.length - 1];
 
-        violations.forEach((node, index) => {
-          const isLast = index === violations.length - 1;
-
+        violations.forEach((node) => {
           context.report({
             node,
             message:
               'Declare this without inline export and list it in a single export statement at the end of the file.',
-            ...(isLast
+            ...(node === lastViolation
               ? {
                   fix(fixer) {
                     const edits = violations.map((exportNode) =>
-                      fixer.replaceText(
-                        exportNode,
-                        sourceCode.getText(exportNode.declaration)
-                      )
+                      fixer.replaceText(exportNode, sourceCode.getText(exportNode.declaration))
                     );
 
-                    const trailingSpecifierExport = findTrailingSpecifierOnlyExport(programNode);
-                    const canMergeIntoTrailing = trailingSpecifierExport && !violations.includes(trailingSpecifierExport);
-                    if (canMergeIntoTrailing) {
-                      const existingItems = parseSpecifierOnlyExportItems(trailingSpecifierExport);
-                      const mergedItems = mergeExportItems(existingItems, addedExportItems);
+                    const existingExport = findSpecifierOnlyExport(programNode);
+                    if (existingExport) {
+                      const merged = mergeExportItems(
+                        getSpecifierOnlyExportItems(existingExport),
+                        addedExportItems
+                      );
                       edits.push(
-                        fixer.replaceText(
-                          trailingSpecifierExport,
-                          formatMergedSpecifierExport(mergedItems)
-                        )
+                        fixer.replaceText(existingExport, formatMergedSpecifierExport(merged))
                       );
                     } else {
-                      const lastProgramToken =
-                        sourceCode.getLastToken(programNode);
-                      const exportLine = `\n\n${formatMergedSpecifierExport(addedExportItems)}`;
+                      const lastToken = sourceCode.getLastToken(programNode);
                       edits.push(
-                        fixer.insertTextAfter(lastProgramToken, exportLine)
+                        fixer.insertTextAfter(
+                          lastToken,
+                          `\n\n${formatMergedSpecifierExport(addedExportItems)}`
+                        )
                       );
                     }
 
@@ -195,7 +134,7 @@ const exportAtEndOfFileRule = {
                 }
               : {}),
           });
-        });
+        }
       },
     };
   },

--- a/lib/rules/export-at-end-of-file.js
+++ b/lib/rules/export-at-end-of-file.js
@@ -1,3 +1,7 @@
+// AST node types we treat as "exportable declarations" — i.e. things you can
+// inline-export with `export function`, `export class`, `export type`, or
+// `export interface`. The `TS*` types come from typescript-eslint and only
+// appear when the file is parsed with the TS parser.
 const EXPORTABLE_DECLARATION_TYPES = new Set([
   'FunctionDeclaration',
   'ClassDeclaration',
@@ -5,19 +9,46 @@ const EXPORTABLE_DECLARATION_TYPES = new Set([
   'TSInterfaceDeclaration',
 ]);
 
+// Subset of the above that exists only at the type level. When listed at the
+// bottom of the file these need either `export type { … }` or per-name
+// `type` markers so tools like `verbatimModuleSyntax` keep them erased.
 const TYPE_ONLY_DECLARATION_TYPES = new Set([
   'TSTypeAliasDeclaration',
   'TSInterfaceDeclaration',
 ]);
 
+/**
+ * Determines whether an AST node is an inline-exported declaration that this
+ * rule should flag. Matches statements like `export function foo() {}` or
+ * `export type Foo = …`, but ignores re-exports (`export { x } from '…'`)
+ * and bare specifier exports (`export { x }`).
+ *
+ * @param {object} node - Top-level program statement node.
+ * @returns {boolean} True when the node is an inline `export <decl>` form
+ *   covering function, class, type alias, or interface declarations.
+ */
 function isInlineExportableDeclaration(node) {
+  // `node.source` is non-null for re-exports (`export { x } from '…'`) and
+  // `node.declaration` is null for bare specifier exports (`export { x }`).
   if (node.type !== 'ExportNamedDeclaration' || node.source || !node.declaration) {
     return false;
   }
   const { declaration } = node;
+  // `declaration.id` is null for anonymous default-export-style declarations,
+  // which don't apply here but we guard against it for safety.
   return EXPORTABLE_DECLARATION_TYPES.has(declaration.type) && Boolean(declaration.id);
 }
 
+/**
+ * Extracts the exported name (and whether it's type-only) from an inline
+ * export declaration so it can be appended to the consolidated export list.
+ *
+ * @param {object} exportNamedNode - An `ExportNamedDeclaration` node that
+ *   has already been validated by {@link isInlineExportableDeclaration}.
+ * @returns {{ name: string, isType: boolean }} Export item describing the
+ *   declared identifier and whether it should be marked `type` in the final
+ *   export statement.
+ */
 function getExportItem(exportNamedNode) {
   const { declaration } = exportNamedNode;
   return {
@@ -26,9 +57,25 @@ function getExportItem(exportNamedNode) {
   };
 }
 
+/**
+ * Reads the items from an existing specifier-only export statement so they
+ * can be merged with the items we are about to append.
+ *
+ * Handles both forms of type-only exports:
+ *   - Statement-level: `export type { Foo, Bar }` → `exportNode.exportKind === 'type'`
+ *   - Per-specifier:   `export { type Foo, bar }` → `specifier.exportKind === 'type'`
+ *
+ * @param {object} exportNode - An `ExportNamedDeclaration` with no
+ *   `declaration` and no `source` (i.e. a bare `export { … }`).
+ * @returns {Array<{ name: string, isType: boolean }>} The specifier list
+ *   normalized into the same shape returned by {@link getExportItem}.
+ */
 function getSpecifierOnlyExportItems(exportNode) {
   const items = [];
   for (const specifier of exportNode.specifiers) {
+    // Skip `export { x as default }` (handled by ExportSpecifier with non-Identifier
+    // exported, e.g. StringLiteral) and any non-ExportSpecifier nodes a parser
+    // might produce.
     if (specifier.type !== 'ExportSpecifier' || specifier.exported.type !== 'Identifier') {
       continue;
     }
@@ -40,12 +87,31 @@ function getSpecifierOnlyExportItems(exportNode) {
   return items;
 }
 
+/**
+ * Locates an existing bare `export { … }` / `export type { … }` statement at
+ * the program level so the autofix can merge new names into it instead of
+ * appending a second export block.
+ *
+ * @param {object} programNode - The top-level `Program` AST node.
+ * @returns {object | null} The matching `ExportNamedDeclaration`, or null
+ *   when no specifier-only export exists.
+ */
 function findSpecifierOnlyExport(programNode) {
   const results = programNode.body.find(statement => statement.type === 'ExportNamedDeclaration'
      && !statement.declaration && !statement.source && statement.specifiers.length > 0);
   return results || null;
 }
 
+/**
+ * Combines existing export items with newly added ones, preserving order and
+ * dropping duplicates by name (existing wins, so an existing `type` marker
+ * isn't accidentally downgraded to a value export).
+ *
+ * @param {Array<{ name: string, isType: boolean }>} existingItems
+ * @param {Array<{ name: string, isType: boolean }>} addedItems
+ * @returns {Array<{ name: string, isType: boolean }>} Deduplicated, ordered
+ *   list of export items.
+ */
 function mergeExportItems(existingItems, addedItems) {
   const seen = new Set();
   const merged = [];
@@ -62,6 +128,15 @@ function mergeExportItems(existingItems, addedItems) {
   return merged;
 }
 
+/**
+ * Renders a list of export items as a single `export { … }` statement. When
+ * every item is type-only the output uses the statement-level `export type
+ * { … }` form; otherwise mixed lists use per-name `type` markers so type
+ * symbols stay erasable under `verbatimModuleSyntax`/isolated modules.
+ *
+ * @param {Array<{ name: string, isType: boolean }>} items
+ * @returns {string} A single-line export statement (no trailing newline).
+ */
 function formatMergedSpecifierExport(items) {
   if (items.length === 0) {
     return 'export {}';
@@ -89,6 +164,11 @@ const exportAtEndOfFileRule = {
     const { sourceCode } = context;
 
     return {
+      // Use `Program:exit` so we have the full body before deciding whether to
+      // merge into an existing trailing `export { … }`. We also attach the
+      // single, file-spanning autofix to the *last* violation only - ESLint
+      // applies fixes in document order, and reporting the same set of edits
+      // from every violation would race and produce overlapping fixes.
       'Program:exit'(programNode) {
         const violations = programNode.body.filter(isInlineExportableDeclaration);
         if (violations.length === 0) {
@@ -106,6 +186,9 @@ const exportAtEndOfFileRule = {
             ...(node === lastViolation
               ? {
                   fix(fixer) {
+                    // Strip the leading `export` from each violation by
+                    // replacing the whole `ExportNamedDeclaration` node with
+                    // the source text of its inner declaration.
                     const edits = violations.map((exportNode) =>
                       fixer.replaceText(exportNode, sourceCode.getText(exportNode.declaration))
                     );
@@ -120,11 +203,14 @@ const exportAtEndOfFileRule = {
                         fixer.replaceText(existingExport, formatMergedSpecifierExport(merged))
                       );
                     } else {
+                      // No bare export to merge into - append a fresh one
+                      // after the program's last token. Ends with a newline to follow
+                      // best practices.
                       const lastToken = sourceCode.getLastToken(programNode);
                       edits.push(
                         fixer.insertTextAfter(
                           lastToken,
-                          `\n\n${formatMergedSpecifierExport(addedExportItems)}`
+                          `\n\n${formatMergedSpecifierExport(addedExportItems)}\n`
                         )
                       );
                     }
@@ -134,7 +220,7 @@ const exportAtEndOfFileRule = {
                 }
               : {}),
           });
-        }
+        });
       },
     };
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-yenz",
-  "version": "2.2.0-beta.1",
+  "version": "2.2.0-beta.2",
   "description": "Adds custom rules that Jens likes",
   "repository": "https://github.com/JensAstrup/eslint-plugin-yenz",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-yenz",
-  "version": "2.1.1",
+  "version": "2.2.0-beta.1",
   "description": "Adds custom rules that Jens likes",
   "repository": "https://github.com/JensAstrup/eslint-plugin-yenz",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-yenz",
-  "version": "2.2.0-beta.2",
+  "version": "2.2.0",
   "description": "Adds custom rules that Jens likes",
   "repository": "https://github.com/JensAstrup/eslint-plugin-yenz",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "ISC",
   "devDependencies": {
     "eslint": "^10.0.1",
-    "typescript": "^5.0.0",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.0.0"
   },
   "peerDependencies": {

--- a/test/eslint.config.js
+++ b/test/eslint.config.js
@@ -14,6 +14,7 @@ export default [
       'yenz/type-ordering': 'error',
       'yenz/no-loops': 'error',
       'yenz/no-named-arrow-functions': 'error',
+      'yenz/export-at-end-of-file': 'error',
     },
   },
 ];

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -29,7 +29,7 @@ const typedReturn = (x: number): number => x // expect-error yenz/no-named-arrow
 const asyncWithParams = async (x: number) => x // expect-error yenz/no-named-arrow-functions // fix: async function asyncWithParams(x: number) { return x; }
 let lv = () => {} // expect-error yenz/no-named-arrow-functions // fix: function lv() {}
 var vv = () => {} // expect-error yenz/no-named-arrow-functions // fix: function vv() {}
-export const exported = () => {} // expect-error yenz/no-named-arrow-functions // fix: export function exported() {}
+export const exported = () => {} // expect-error yenz/no-named-arrow-functions // fix: function exported() {}
 
 // Should pass:
 const arr2 = [1, 2, 3].map(x => x)
@@ -39,3 +39,11 @@ class MyClass {
 const obj2 = {
   method: () => {}
 }
+
+export function exportFunction() { return 1; } // expect-error yenz/export-at-end-of-file // fix: function exportFunction() { return 1; }
+
+export class ExportClass { method() { return 1; } } // expect-error yenz/export-at-end-of-file // fix: class ExportClass { method() { return 1; } }
+
+export type FixtureExportType = 1 // expect-error yenz/export-at-end-of-file // fix: type FixtureExportType = 1
+
+export interface FixtureExportIface { n: number } // expect-error yenz/export-at-end-of-file // fix: interface FixtureExportIface { n: number }

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -47,3 +47,9 @@ export class ExportClass { method() { return 1; } } // expect-error yenz/export-
 export type FixtureExportType = 1 // expect-error yenz/export-at-end-of-file // fix: type FixtureExportType = 1
 
 export interface FixtureExportIface { n: number } // expect-error yenz/export-at-end-of-file // fix: interface FixtureExportIface { n: number }
+
+// Should pass (export-at-end-of-file — specifier exports and non-exported decls only):
+function notExported() {}
+function someExisting() {}
+export { someExisting }
+export { foo } from './other'

--- a/yarn.lock
+++ b/yarn.lock
@@ -594,10 +594,10 @@ typescript-eslint@^8.0.0:
     "@typescript-eslint/typescript-estree" "8.55.0"
     "@typescript-eslint/utils" "8.55.0"
 
-typescript@^5.0.0:
-  version "5.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
-  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+typescript@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `export-at-end-of-file` ESLint rule to enforce exports at the end of files instead of inline declarations.

* **Documentation**
  * Clarified which rules are enabled in `recommended` vs. `all` presets.
  * Updated release procedures and development guidelines.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JensAstrup/eslint-plugin-yenz/pull/24)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->