### PR TITLE
Document export-at-end-of-file rule in README #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,42 @@ arr.filter((item) => item.active);
 class Foo { bar = () => {} }
 ```
 
+### `yenz/export-at-end-of-file`
+
+Disallows inline exports on function, class, type alias, and interface declarations. Prefer declaring first, then exporting all symbols in one statement at the end of the file. Auto-fixable.
+
+> **Note:** This rule is *not* enabled in the `recommended`. Enable it explicitly or use `all`.
+
+**Bad:**
+
+```typescript
+export function parseDate(input: string) {
+  return new Date(input);
+}
+
+export interface UserProfile {
+  id: string;
+}
+
+export type UserStatus = 'active' | 'inactive';
+```
+
+**Good:**
+
+```typescript
+function parseDate(input: string) {
+  return new Date(input);
+}
+
+interface UserProfile {
+  id: string;
+}
+
+type UserStatus = 'active' | 'inactive';
+
+export { parseDate, type UserProfile, type UserStatus };
+```
+
 ## Preset Configurations
 
 - `**recommended**` - Enables `type-ordering` as error and `no-loops` as warning

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ plugin.configs = {
       'yenz/type-ordering': 'error',
       'yenz/no-loops': 'error',
       'yenz/no-named-arrow-functions': 'error',
+      'yenz/export-at-end-of-file': 'error',
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-yenz",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Adds custom rules that Jens likes",
   "repository": "https://github.com/JensAstrup/eslint-plugin-yenz",
   "type": "module",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `yenz/export-at-end-of-file` ESLint rule that disallows inline exports on functions, classes, type aliases, and interfaces; rule is auto-fixable and not enabled in the recommended preset.

* **Documentation**
  * Added rule documentation with examples of bad vs. good export syntax.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JensAstrup/eslint-plugin-yenz/pull/26)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->